### PR TITLE
Support auto_impl on borrowed references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auto_impl"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT"
 description = "Automatically implement traits for common smart pointers and closures"

--- a/compile_test/src/main.rs
+++ b/compile_test/src/main.rs
@@ -19,7 +19,7 @@ trait FnTrait3 {
     fn execute(&mut self);
 }
 
-#[auto_impl(Arc, Box, Rc)]
+#[auto_impl(Arc, Box, Rc, &, &mut)]
 trait RefTrait1<'a, T: for<'b> Into<&'b str>> {
     type Type1;
     type Type2;

--- a/src/impl_as_ref.rs
+++ b/src/impl_as_ref.rs
@@ -8,9 +8,7 @@ use model::*;
 /// 
 /// - The smart pointer wraps a single generic value, like `Arc<T>`, `Box<T>`, `Rc<T>`
 /// - The smart pointer implements `AsRef<T>`
-pub fn build(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, String> {
-    let component_ident = &component.ident;
-
+pub fn build_wrapper(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, String> {
     let impl_methods = component.methods.iter()
         .map(|method| {
             let valid_receiver = match method.arg_self {
@@ -36,6 +34,64 @@ pub fn build(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, String> {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    build(component, vec![], quote!(#ref_ty < TAutoImpl >), impl_methods)
+}
+
+/// Auto implement a trait for an immutable reference.
+/// 
+/// This expects the input to have the following properties:
+/// 
+/// - All methods have an `&self` receiver
+pub fn build_immutable(component: &AutoImpl) -> Result<Tokens, String> {
+    let impl_methods = component.methods.iter()
+        .map(|method| {
+            let valid_receiver = match method.arg_self {
+                Some(ref arg_self) => match *arg_self {
+                    SelfArg::Ref(_, syn::Mutability::Immutable) => true,
+                    _ => false
+                },
+                None => false
+            };
+
+            if !valid_receiver {
+                Err("auto impl for `&T` is only supported for methods with a `&self` reciever")?
+            }
+
+            method.build_impl_item(|method| {
+                let fn_ident = &method.ident;
+                let fn_args = &method.arg_pats;
+
+                quote!({
+                    (**self).#fn_ident( #(#fn_args),* )
+                })
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    build(component, vec![quote!('auto)], quote!(&'auto TAutoImpl), impl_methods)
+}
+
+/// Auto implement a trait for a mutable reference.
+pub fn build_mutable(component: &AutoImpl) -> Result<Tokens, String> {
+    let impl_methods = component.methods.iter()
+        .map(|method| {
+            method.build_impl_item(|method| {
+                let fn_ident = &method.ident;
+                let fn_args = &method.arg_pats;
+
+                quote!({
+                    (**self).#fn_ident( #(#fn_args),* )
+                })
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    
+    build(component, vec![quote!('auto)], quote!(&'auto mut TAutoImpl), impl_methods)
+}
+
+fn build(component: &AutoImpl, extra_lifetimes: Vec<Tokens>, impl_ident: Tokens, impl_methods: Vec<syn::TraitItem>) -> Result<Tokens, String> {
+    let component_ident = &component.ident;
+
     let impl_associated_types = component.associated_types.iter()
         .map(|associated_type| {
             associated_type.build_impl_item(|associated_type| {
@@ -49,7 +105,7 @@ pub fn build(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, String> {
     let (trait_tys, impl_lifetimes, impl_tys, where_clauses) = component.split_generics();
 
     Ok(quote!(
-        impl< #(#impl_lifetimes,)* #(#impl_tys,)* TAutoImpl > #component_ident #trait_tys for #ref_ty < TAutoImpl >
+        impl< #(#extra_lifetimes,)* #(#impl_lifetimes,)* #(#impl_tys,)* TAutoImpl > #component_ident #trait_tys for #impl_ident
             where TAutoImpl: #component_ident #trait_tys
                   #(,#where_clauses)*
         {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,53 @@
+use std::str;
+
+pub fn attr<'a>(input: &'a str) -> Result<Vec<String>, String> {
+    fn remove_whitespace(i: &[u8]) -> String {
+        let ident = i.iter().filter(|c| **c != b' ').cloned().collect();
+        String::from_utf8(ident).expect("non-utf8 string")
+    }
+
+    fn ident(i: &[u8]) -> (String, &[u8]) {
+        if let Some(end) = i.iter().position(|c| *c == b',') {
+            (remove_whitespace(&i[..end]), &i[end..])
+        }
+        else {
+            (remove_whitespace(i), &[])
+        }
+    }
+
+    fn attr_inner<'a>(rest: &'a [u8], traits: &mut Vec<String>) -> Result<(), String> {
+        match rest.len() {
+            0 => Ok(()),
+            _ => {
+                match rest[0] as char {
+                    '&' => {
+                        let (ident, rest) = ident(rest);
+                        traits.push(ident);
+
+                        attr_inner(rest, traits)
+                    },
+                    c if c.is_alphabetic() => {
+                        let (ident, rest) = ident(rest);
+                        traits.push(ident);
+
+                        attr_inner(rest, traits)
+                    },
+                    _ => attr_inner(&rest[1..], traits)
+                }
+            }
+        }
+    }
+
+    let mut traits = vec![];
+    let input = input.as_bytes();
+
+    let open = input.iter().position(|c| *c == b'(');
+    let close = input.iter().position(|c| *c == b')');
+
+    match (open, close) {
+        (Some(open), Some(close)) => attr_inner(&input[open..close], &mut traits)?,
+        _ => Err("attribute format should be `#[auto_impl(a, b, c)]`")?
+    }
+
+    Ok(traits)
+}


### PR DESCRIPTION
Closes #3 

I've added a poor-man's parser for the `#[auto_impl]` attribute so we can parse `&` and `&mut` correctly. We could probably do a better job of sharing code for smart pointers and reference types and dealing with malformed input, but this should be good enough.