### PR TITLE
Support by-value and static methods where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auto_impl"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT"
 description = "Automatically implement traits for common smart pointers and closures"

--- a/README.md
+++ b/README.md
@@ -22,23 +22,88 @@ extern crate auto_impl;
 use auto_impl::auto_impl;
 ```
 
-The following types are supported:
+Add an `auto_impl` attribute to traits you want to automatically implement for wrapper types:
+
+```rust
+#[auto_impl(&, Arc)]
+pub trait OrderStoreFilter {
+    fn filter<F>(&self, predicate: F) -> Result<Iter, Error>
+    where
+        F: Fn(&OrderData) -> bool;
+}
+```
+
+Now anywhere that requires a `T: OrderStoreFilter` will also accept an `&T` or `Arc<T>` where `T` implements `OrderStoreFilter`.
+
+## Specifics
+
+The following types are supported and can be freely combined:
 
 - [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html)
 - [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html)
 - [`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html)
+
+The following types are also supported, but require a blanket implementation (you can only have one of these per `trait`):
+
 - [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)
 - [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html)
 - [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)
 - `&`
 - `&mut`
 
+## Implement a trait for `Box`
+
+```rust
+#[auto_impl(Box)]
+trait MyTrait<'a, T> 
+    where T: AsRef<str>
+{
+    type Type1;
+    type Type2;
+
+    fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String>;
+    fn execute2(&self) -> Self::Type2;
+    fn execute3(self) -> Self::Type1;
+    fn execute4() -> &'static str;
+}
+```
+
+Will expand to:
+
+```rust
+impl<'a, T, TAutoImpl> MyTrait<'a, T> for ::std::boxed::Box<TAutoImpl>
+    where TAutoImpl: MyTrait<'a, T>,
+          T: AsRef<str>
+{
+    type Type1 = TAutoImpl::Type1;
+    type Type2 = TAutoImpl::Type2;
+
+    fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String> {
+        (**self).execute1(arg1)
+    }
+
+    fn execute2(&self) -> Self::Type2 {
+        (**self).execute2()
+    }
+
+    fn execute3(self) -> Self::Type1 {
+        (*self).execute3()
+    }
+
+    fn execute4() -> &'static str {
+        TAutoImpl::execute4()
+    }
+}
+```
+
+There are no restrictions on `auto_impl` for `Box`.
+
 ## Implement a trait for a smart pointer
 
 Add the `#[auto_impl]` attribute to traits to automatically implement them for wrapper types:
 
 ```rust
-#[auto_impl(Arc, Box, Rc)]
+#[auto_impl(Arc, Rc)]
 trait MyTrait<'a, T> 
     where T: AsRef<str>
 {
@@ -61,27 +126,11 @@ impl<'a, T, TAutoImpl> MyTrait<'a, T> for ::std::sync::Arc<TAutoImpl>
     type Type2 = TAutoImpl::Type2;
 
     fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String> {
-        self.as_ref().execute1(arg1)
+        (**self).execute1(arg1)
     }
 
     fn execute2(&self) -> Self::Type2 {
-        self.as_ref().execute2()
-    }
-}
-
-impl<'a, T, TAutoImpl> MyTrait<'a, T> for Box<TAutoImpl>
-    where TAutoImpl: MyTrait<'a, T>,
-          T: AsRef<str>
-{
-    type Type1 = TAutoImpl::Type1;
-    type Type2 = TAutoImpl::Type2;
-
-    fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String> {
-        self.as_ref().execute1(arg1)
-    }
-
-    fn execute2(&self) -> Self::Type2 {
-        self.as_ref().execute2()
+        (**self).execute2()
     }
 }
 
@@ -93,18 +142,18 @@ impl<'a, T, TAutoImpl> MyTrait<'a, T> for ::std::rc::Rc<TAutoImpl>
     type Type2 = TAutoImpl::Type2;
 
     fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String> {
-        self.as_ref().execute1(arg1)
+        (**self).execute1(arg1)
     }
 
     fn execute2(&self) -> Self::Type2 {
-        self.as_ref().execute2()
+        (**self).execute2()
     }
 }
 ```
 
 There are a few restrictions on `#[auto_impl]` for smart pointers. The trait must:
 
-- Only have methods that take `&self`
+- Only have methods that take `&self` or have no receiver (static)
 
 ## Implement a trait for a closure
 
@@ -119,7 +168,7 @@ Will expand to:
 
 ```rust
 impl<'a, T, TAutoImpl> MyTrait<'a, T> for TAutoImpl
-    where TAutoImpl: Fn(&T, &'static str) -> Result<(), String>
+    where TAutoImpl: ::std::ops::Fn(&T, &'static str) -> Result<(), String>
 {
     fn execute<'b>(&'a self, arg1: &'b T, arg1: &'static str) -> Result<(), String> {
         self(arg1, arg2)
@@ -160,6 +209,8 @@ impl<'auto, 'a, T, TAutoImpl> MyTrait<'a, T> for &'auto mut TAutoImpl {
 
 There are a few restrictions on `#[auto_impl]` for immutably borrowed references. The trait must:
 
-- Only have methods that take `&self`
+- Only have methods that take `&self` or have no receiver (static)
 
-There are no restrictions on `#[auto_impl]` for mutably borrowed references.
+There are a few restrictions on `#[auto_impl]` for mutably borrowed references. The trait must:
+
+- Only have methods that take `&self`, `&mut self` or have no receiver (static)

--- a/compile_test/src/main.rs
+++ b/compile_test/src/main.rs
@@ -1,3 +1,7 @@
+/*!
+Try running `cargo expand` on this crate to see the output of `#[auto_impl]`.
+*/
+
 #![feature(proc_macro)]
 
 extern crate auto_impl;
@@ -26,6 +30,17 @@ trait RefTrait1<'a, T: for<'b> Into<&'b str>> {
 
     fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String>;
     fn execute2(&self) -> Self::Type2;
+}
+
+#[auto_impl(Box)]
+trait BoxTrait1<'a, T: for<'b> Into<&'b str>> {
+    type Type1;
+    type Type2;
+
+    fn execute1<'b>(&'a self, arg1: &'b T) -> Result<Self::Type1, String>;
+    fn execute2(&mut self, arg1: i32) -> Self::Type2;
+    fn execute3(self) -> Self::Type1;
+    fn execute4(arg1: String) -> Result<i32, String>;
 }
 
 fn main() {

--- a/src/impl_as_ref.rs
+++ b/src/impl_as_ref.rs
@@ -1,40 +1,90 @@
+use std::fmt;
 use syn;
 use quote::Tokens;
 use model::*;
+
+pub struct WrapperTrait {
+    inner: Trait,
+    valid_receivers: ValidReceivers,
+}
+
+impl WrapperTrait {
+    pub fn impl_rc() -> Self {
+        WrapperTrait {
+            inner: Trait::new("Rc", quote!(::std::rc::Rc)),
+            valid_receivers: ValidReceivers {
+                ref_self: true,
+                no_self: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn impl_arc() -> Self {
+        WrapperTrait {
+            inner: Trait::new("Arc", quote!(::std::sync::Arc)),
+            valid_receivers: ValidReceivers {
+                ref_self: true,
+                no_self: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn impl_box() -> Self {
+        WrapperTrait {
+            inner: Trait::new("Box", quote!(::std::boxed::Box)),
+            valid_receivers: ValidReceivers {
+                ref_self: true,
+                ref_mut_self: true,
+                value_self: true,
+                no_self: true,
+            },
+        }
+    }
+}
+
+pub struct RefTrait {
+    inner: Trait,
+    valid_receivers: ValidReceivers,
+}
+
+impl RefTrait {
+    pub fn impl_ref() -> Self {
+        RefTrait {
+            inner: Trait::new("&T", quote!(&'auto)),
+            valid_receivers: ValidReceivers {
+                ref_self: true,
+                no_self: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn impl_ref_mut() -> Self {
+        RefTrait {
+            inner: Trait::new("&mut T", quote!(&'auto mut)),
+            valid_receivers: ValidReceivers {
+                ref_self: true,
+                ref_mut_self: true,
+                no_self: true,
+                ..Default::default()
+            },
+        }
+    }
+}
 
 /// Auto implement a trait for a smart pointer.
 /// 
 /// This expects the input type to have the following properties:
 /// 
-/// - The smart pointer wraps a single generic value, like `Arc<T>`, `Box<T>`, `Rc<T>`
+/// - The smart pointer wraps a single generic value, like `Arc<T>`, `Rc<T>`
 /// - The smart pointer implements `AsRef<T>`
-pub fn build_wrapper(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, String> {
-    let impl_methods = component.methods.iter()
-        .map(|method| {
-            let valid_receiver = match method.arg_self {
-                Some(ref arg_self) => match *arg_self {
-                    SelfArg::Ref(_, syn::Mutability::Immutable) => true,
-                    _ => false
-                },
-                None => false
-            };
+pub fn build_wrapper(component: &AutoImpl, ref_ty: WrapperTrait) -> Result<Tokens, String> {
+    let inner = ref_ty.inner;
+    let impl_ident = quote!(#inner < TAutoImpl >);
 
-            if !valid_receiver {
-                Err(format!("auto impl for `{}` is only supported for methods with a `&self` reciever", ref_ty))?
-            }
-
-            method.build_impl_item(|method| {
-                let fn_ident = &method.ident;
-                let fn_args = &method.arg_pats;
-
-                quote!({
-                    self.as_ref().#fn_ident( #(#fn_args),* )
-                })
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    build(component, vec![], quote!(#ref_ty < TAutoImpl >), impl_methods)
+    build(inner, ref_ty.valid_receivers, vec![], component, impl_ident)
 }
 
 /// Auto implement a trait for an immutable reference.
@@ -42,55 +92,94 @@ pub fn build_wrapper(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, Stri
 /// This expects the input to have the following properties:
 /// 
 /// - All methods have an `&self` receiver
-pub fn build_immutable(component: &AutoImpl) -> Result<Tokens, String> {
+pub fn build_ref(component: &AutoImpl, ref_ty: RefTrait) -> Result<Tokens, String> {
+    let inner = ref_ty.inner;
+    let impl_ident = quote!(#inner TAutoImpl);
+
+    build(inner, ref_ty.valid_receivers, vec![quote!('auto)], component, impl_ident)
+}
+
+#[derive(Default)]
+struct ValidReceivers {
+    ref_self: bool,
+    ref_mut_self: bool,
+    value_self: bool,
+    no_self: bool,
+}
+
+impl fmt::Display for ValidReceivers {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut valid_receivers = vec![];
+
+        if self.ref_self {
+            valid_receivers.push("`&self`");
+        }
+        if self.ref_mut_self {
+            valid_receivers.push("`&mut self`");
+        }
+        if self.value_self {
+            valid_receivers.push("`self`");
+        }
+        if self.no_self {
+            valid_receivers.push("static");
+        }
+
+        match valid_receivers.len() {
+            0 => unreachable!(),
+            1 => {
+                write!(f, "{}", valid_receivers[0])
+            }
+            n => {
+                let first = &valid_receivers[..n - 1].join(", ");
+                let last = &valid_receivers[n - 1];
+
+                write!(f, "{} or {}", first, last)
+            }
+        }
+    }
+}
+
+fn build(ref_ty: Trait, valid_receivers: ValidReceivers, extra_lifetimes: Vec<Tokens>, component: &AutoImpl, impl_ident: Tokens) -> Result<Tokens, String> {
+    let component_ident = &component.ident;
+
     let impl_methods = component.methods.iter()
         .map(|method| {
             let valid_receiver = match method.arg_self {
                 Some(ref arg_self) => match *arg_self {
-                    SelfArg::Ref(_, syn::Mutability::Immutable) => true,
-                    _ => false
+                    SelfArg::Ref(_, syn::Mutability::Immutable) => valid_receivers.ref_self,
+                    SelfArg::Ref(_, syn::Mutability::Mutable) => valid_receivers.ref_mut_self,
+                    SelfArg::Value(_) => valid_receivers.value_self,
                 },
-                None => false
+                None => valid_receivers.no_self
             };
 
             if !valid_receiver {
-                Err("auto impl for `&T` is only supported for methods with a `&self` reciever")?
+                Err(format!("auto impl for `{}` is only supported for methods with a {} reciever", ref_ty, valid_receivers))?
             }
 
             method.build_impl_item(|method| {
                 let fn_ident = &method.ident;
                 let fn_args = &method.arg_pats;
 
-                quote!({
-                    (**self).#fn_ident( #(#fn_args),* )
-                })
+                match method.arg_self {
+                    Some(ref arg_self) => match *arg_self {
+                        // `&self` or `&mut self`
+                        SelfArg::Ref(_, _) => quote!({
+                            (**self).#fn_ident( #(#fn_args),* )
+                        }),
+                        // `self`
+                        _ => quote!({
+                            (*self).#fn_ident( #(#fn_args),* )
+                        })
+                    },
+                    // No `self`
+                    None => quote!({
+                        TAutoImpl :: #fn_ident( #(#fn_args),* )
+                    })
+                }
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
-
-    build(component, vec![quote!('auto)], quote!(&'auto TAutoImpl), impl_methods)
-}
-
-/// Auto implement a trait for a mutable reference.
-pub fn build_mutable(component: &AutoImpl) -> Result<Tokens, String> {
-    let impl_methods = component.methods.iter()
-        .map(|method| {
-            method.build_impl_item(|method| {
-                let fn_ident = &method.ident;
-                let fn_args = &method.arg_pats;
-
-                quote!({
-                    (**self).#fn_ident( #(#fn_args),* )
-                })
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    
-    build(component, vec![quote!('auto)], quote!(&'auto mut TAutoImpl), impl_methods)
-}
-
-fn build(component: &AutoImpl, extra_lifetimes: Vec<Tokens>, impl_ident: Tokens, impl_methods: Vec<syn::TraitItem>) -> Result<Tokens, String> {
-    let component_ident = &component.ident;
 
     let impl_associated_types = component.associated_types.iter()
         .map(|associated_type| {

--- a/src/impl_fn.rs
+++ b/src/impl_fn.rs
@@ -2,6 +2,30 @@ use syn;
 use quote::Tokens;
 use model::*;
 
+pub struct FnTrait {
+    inner: Trait,
+}
+
+impl FnTrait {
+    pub fn impl_fn() -> Self {
+        FnTrait {
+            inner: Trait::new("Fn", quote!(::std::ops::Fn))
+        }
+    }
+
+    pub fn impl_fn_mut() -> Self {
+        FnTrait {
+            inner: Trait::new("FnMut", quote!(::std::ops::FnMut))
+        }
+    }
+
+    pub fn impl_fn_once() -> Self {
+        FnTrait {
+            inner: Trait::new("FnOnce", quote!(::std::ops::FnOnce))
+        }
+    }
+}
+
 /// Auto implement a trait for a function.
 /// 
 /// This expects the input type to have the following properties:
@@ -13,7 +37,9 @@ use model::*;
 /// - It has a single method
 /// - It has no associated type
 /// - It has no non-static lifetimes in the return type
-pub fn build(component: &AutoImpl, ref_ty: Trait) -> Result<Tokens, String> {
+pub fn build(component: &AutoImpl, ref_ty: FnTrait) -> Result<Tokens, String> {
+    let ref_ty = ref_ty.inner;
+
     let method = expect_single_method(component, &ref_ty)?;
 
     expect_static_lifetimes_in_return_ty(&method, &ref_ty)?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,12 +20,14 @@ pub fn attr<'a>(input: &'a str) -> Result<Vec<String>, String> {
             0 => Ok(()),
             _ => {
                 match rest[0] as char {
+                    // Parse a borrowed reference
                     '&' => {
                         let (ident, rest) = ident(rest);
                         traits.push(ident);
 
                         attr_inner(rest, traits)
                     },
+                    // Parse a regular ident
                     c if c.is_alphabetic() => {
                         let (ident, rest) = ident(rest);
                         traits.push(ident);
@@ -45,7 +47,7 @@ pub fn attr<'a>(input: &'a str) -> Result<Vec<String>, String> {
     let close = input.iter().position(|c| *c == b')');
 
     match (open, close) {
-        (Some(open), Some(close)) => attr_inner(&input[open..close], &mut traits)?,
+        (Some(open), Some(close)) => attr_inner(&input[open + 1 .. close], &mut traits)?,
         _ => Err("attribute format should be `#[auto_impl(a, b, c)]`")?
     }
 


### PR DESCRIPTION
Closes #5 

`0.1.2` was a little half-baked so I've cleaned things up in addition to:

- Using consistent dereferencing to get to the method implementation we want to call
- Supporting static methods where possible (it's pretty much always possible)
- Supporting by-value methods for `Box` since it owns its input and can move out of it